### PR TITLE
avoid failure to publish from circleci

### DIFF
--- a/src/publish
+++ b/src/publish
@@ -1,5 +1,5 @@
-#!/bin/bash
-set -eEu
+#!/bin/sh
+set -eu
 set -o pipefail
 
 . vars
@@ -10,7 +10,7 @@ chmod 0600 ~/.gem/credentials
 sed -i "s/API_KEY/${API_KEY}/" ~/.gem/credentials
 
 output="$(gem search --remote -a puppet-autostager)"
-if [[ "${output}" =~ ${VERSION} ]]; then
+if echo "${output}" | grep -q  "${VERSION}"; then
   # Be informative, but don't fail.
   # This enables to merge changes to non-gem files, such as README.
   echo "puppet-autostager ${VERSION} has already been published."


### PR DESCRIPTION
Before this commit:
Commit 3ba6de414ca7d8250d changed the gem publish script to bash,
but bash is not in the builder image.

After this commit:
Change back to posix script rather than add bash.