### PR TITLE
lib: add ability to specify a git server

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ export sleep_interval=60
 
 # Or run as a single-shot operation.
 export sleep_interval=0
+
+# Set an alternate git server (default: github.com)
+export git_server=git.example.com
 ```
 
 Then run:

--- a/src/lib/autostager.rb
+++ b/src/lib/autostager.rb
@@ -20,6 +20,10 @@ module Autostager
     ENV['access_token']
   end
 
+  def git_server
+    ENV['git_server'] || 'github.com'
+  end
+
   # Convert a string into purely alphanumeric characters
   def alphafy(a_string)
     a_string.gsub(/[^a-z0-9_]/i, '_')
@@ -37,10 +41,10 @@ module Autostager
     log "===> begin #{default_branch}"
     p = Autostager::PullRequest.new(
       default_branch,
-      authenticated_url("https://github.com/#{repo_slug}"),
+      authenticated_url("https://#{git_server}/#{repo_slug}"),
       base_dir,
       default_branch,
-      authenticated_url("https://github.com/#{repo_slug}"),
+      authenticated_url("https://#{git_server}/#{repo_slug}"),
     )
     p.clone unless p.staged?
     p.fetch


### PR DESCRIPTION
before: github.com hard coded

after: leverage an optional environment variable `git_server`.
If a git_server environment variable is not provided, autostager
will default to github.com