### PR TITLE
README: add note about API endpoint for Octokit

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ export sleep_interval=0
 
 # Set an alternate git server (default: github.com)
 export git_server=git.example.com
+export OCTOKIT_API_ENDPOINT=https://git.example.com/api/v3/
 ```
 
 Then run:


### PR DESCRIPTION
* autostager uses Octokit to interact with github.com API by default

To override this behavior for github enterprise versions,
simply provide the environment variable noted in the README.