### PR TITLE
lib: modify autostager to prevent discard of master branch

### DIFF
--- a/src/lib/autostager.rb
+++ b/src/lib/autostager.rb
@@ -150,6 +150,7 @@ module Autostager
     [
       '.',
       '..',
+      'master',
       'production',
     ]
   end


### PR DESCRIPTION
before: autostager only preserves the production branch, which
is the typical default for puppet

after: autostager will also preserve the master branch.  This is
needed in git repos when the master branch is the default.

The use case for this wrt puppet is when you specify an
environment=master in your puppet.conf to align with vcs instead
of using the puppet's default environment equal to production.