### PR TITLE
ci: use native pre-commit feature instead of a hack for gitlint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,6 @@ repos:
 
       - id: gitlint
         entry: gitlint --commits upstream/master..
-        exclude: .*
+        pass_filenames: false
         always_run: true
         stages: [manual]


### PR DESCRIPTION
Thanks @asottile for the tip.